### PR TITLE
EXTADT-51: fix optimizer failed by cac timeout

### DIFF
--- a/feeds/wifi-mt76xx/hostapd/patches/995-hostap-multi-VIF-reload-fix.patch
+++ b/feeds/wifi-mt76xx/hostapd/patches/995-hostap-multi-VIF-reload-fix.patch
@@ -1,0 +1,33 @@
+--- a/src/ap/hostapd.c
++++ b/src/ap/hostapd.c
+@@ -2137,7 +2137,7 @@ static int hostapd_setup_interface_compl
+ 		hapd = iface->bss[j];
+ 		if (j)
+ 			os_memcpy(hapd->own_addr, prev_addr, ETH_ALEN);
+-		if (hostapd_setup_bss(hapd, j == 0)) {
++		if (hostapd_setup_bss(hapd, (j == 0) ? 1 : -1)) {
+ 			for (;;) {
+ 				hapd = iface->bss[j];
+ 				hostapd_bss_deinit_no_free(hapd);
+--- a/src/drivers/driver_nl80211.c
++++ b/src/drivers/driver_nl80211.c
+@@ -196,7 +196,8 @@ static int nl80211_put_mesh_config(struc
+ #endif /* CONFIG_MESH */
+ static int i802_sta_disassoc(void *priv, const u8 *own_addr, const u8 *addr,
+ 			     u16 reason);
+-
++static int nl80211_put_freq_params(struct nl_msg *msg,
++				const struct hostapd_freq_params *freq);
+ 
+ /* Converts nl80211_chan_width to a common format */
+ enum chan_width convert2width(int width)
+@@ -4487,6 +4488,9 @@ static int wpa_driver_nl80211_set_ap(voi
+ 			goto fail;
+ 	}
+ #endif /* CONFIG_IEEE80211AX */
++	if (params->freq && nl80211_put_freq_params(msg, params->freq))
++		wpa_printf(MSG_DEBUG, "nl80211: Failed to add freq params: %d (%s)",
++			ret, strerror(-ret));
+ 
+ 	ret = send_and_recv_msgs_owner(drv, msg, get_connect_handle(bss), 1,
+ 				       NULL, NULL);


### PR DESCRIPTION
Hostapd deletes and re-adds the AP VIFs on channel switch to
DFS channel.

But due to we don't put bssid in hostapd config, it will let the kernel
mac80111 layer decide the MAC address which would be the first
available MAC address (derive from the radio base address).

Interfaces are removed and re-added only on interface reload
and not the first time interface is added.

Signed-off-by: Jeremy Yang <jyang@plume.com>